### PR TITLE
Fix background-color css

### DIFF
--- a/_sass/4-layouts/_post.scss
+++ b/_sass/4-layouts/_post.scss
@@ -146,7 +146,7 @@
       background-position: center;
       background-size: cover;
       background-repeat: no-repeat;
-      background: $light-gray;
+      background-color: $light-gray;
       transition: .35s ease-in-out;
       &:hover {
         opacity: 0.9;


### PR DESCRIPTION
Thank you for this fantastic theme!

A minor fix: 

**Before:**

![image](https://user-images.githubusercontent.com/483298/92306699-d2e82a80-efae-11ea-99cd-63e0e7a85c9b.png)

Using `background-color` css property instead to set the color, fixes this.