### PR TITLE
Add filter in url for tags Fix #4

### DIFF
--- a/_includes/article-content.html
+++ b/_includes/article-content.html
@@ -17,7 +17,7 @@
           {% if post.tags.size >= 1 %}
             <div class="article-tags__box">
               {% for tag in post.tags %}
-                <a href="{{ site.baseurl }}/tag/{{ tag }}" class="article__tag">{{ tag }}</a>
+                <a href="{{ site.baseurl }}/tag/{{ tag | downcase | replace: " ", "-" }}" class="article__tag">{{ tag }}</a>
               {% endfor %}
             </div>
           {% else %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,7 +20,7 @@ layout: default
           {% if page.tags.size >= 1 %}
           <div class="post__tags">
             {% for tag in page.tags %}
-              <a href="{{ site.baseurl }}/tag/{{ tag }}" class="post__tags-tag">{{ tag }}</a>
+              <a href="{{ site.baseurl }}/tag/{{ tag | downcase | replace: " ", "-" }}" class="post__tags-tag">{{ tag }}</a>
             {% endfor %}
           </div>
           {% endif %}


### PR DESCRIPTION
If a filter is applied to put the tags in lowercase and another one to change the spaces to hyphens, there is no longer a 404 route and it works correctly also in local deploy